### PR TITLE
Metric refactor

### DIFF
--- a/healthdata/admin.py
+++ b/healthdata/admin.py
@@ -5,8 +5,7 @@ from .models import ProtoHealth, ScoreMetric, ScoreNode
 
 
 class ScoreMetricAdmin(admin.ModelAdmin):
-    list_display = (
-        'name', 'data_source', 'boundary_set', 'data_property', 'algorithm')
+    list_display = ('name', 'algorithm')
 
 
 class ScoreNodeAdmin(MPTTModelAdmin):

--- a/healthdata/algorithms.py
+++ b/healthdata/algorithms.py
@@ -3,146 +3,288 @@
 from collections import OrderedDict
 import random
 
-from django.utils.text import slugify
+from django.core.urlresolvers import reverse
 from scipy.stats import norm
 
 from boundaryservice.models import Boundary
+from healthdata.utils import fake_boundary
 from data.models import Census
 
 
-def boundaries(point):
-    '''Return boundaries containing the point'''
-    wkt = 'POINT({} {})'.format(*point)
-    return Boundary.objects.filter(shape__contains=wkt)
-
-
-def boundary_dict(boundary):
-    '''Convert a boundary to a dictionary'''
-    return OrderedDict((
-        ('path', '/api/boundary/{}/'.format(boundary.slug)),
-        ('label', boundary.display_name),
-        ('year', 2013),
-        ('type', boundary.set.name),
-        ('external_id', boundary.external_id),
-        ('id', boundary.slug),
-    ))
-
-
 class BaseAlgorithm(object):
-    def __init__(self, metric):
+    def __init__(self, node, metric):
+        self.node = node
         self.metric = metric
 
-    def calculate(self, point):
-        raise NotImplementedError('Algorithm is not implemented')
+    def boundaries_for_location(self, location):
+        '''
+        Generate boundaries for a (lon, lat) location
+
+        Return should be a iterable of Boundary objects in preferred order
+        '''
+        raise NotImplementedError('boundaries_for_location is not implemented')
+
+    def source_data_for_boundary(self, boundary):
+        '''
+        Return source data for a boundary
+
+        Return should be a source data instance with appropriate data,
+        or None if no data for the boundary.
+        '''
+        raise NotImplementedError(
+            'source_data_for_boundary is not implemented')
+
+    def score(self, source_data):
+        '''
+        Score an item of source data
+
+        Return should be a dictionary with at least:
+        {
+            'summary': {
+                'score': (the score, 0.0 to 1.0),
+                'value': (the raw value),
+                'value_type': (the type of the value, such as 'percent'),
+                'description': (a short description of the metric),
+            }
+        }
+        It can include more summary items.
+        It can also include a 'detail' dictionary with additional information
+
+        TODO: more required details
+        '''
+        raise NotImplementedError('score is not implemented')
+
+    def source_data_for_location(self, location):
+        '''Generate source data for a (lon, lat) location'''
+        for boundary in self.boundaries_for_location(location):
+            source_data = self.source_data_for_boundary(boundary)
+            if source_data:
+                yield source_data
+
+    def boundary_path(self, boundary):
+        '''Return the path to the boundary API endpoint'''
+        return reverse('api:boundary', kwargs={'slug': boundary.slug})
+
+    def detail_path(self, boundary):
+        '''Return the path to the metric detail API endpoint'''
+        return reverse(
+            'api:metric-detail', kwargs={
+                'boundary_slug': boundary.slug, 'node_slug': self.node.slug})
+
+    def calculate(self, source_data):
+        '''
+        Calculate a metric dictionary from valid source data
+
+        Return is a dictionary with three items: summary, detail, and boundary
+        '''
+        calculation = self.score(source_data)
+        boundary = source_data.boundary
+        calculation.setdefault('detail', {}).update({
+            'path': self.detail_path(boundary),
+        })
+        calculation.setdefault('boundary', {}).update({
+            'path': self.boundary_path(boundary),
+        })
+        return calculation
+
+    def calculate_by_boundary(self, boundary):
+        '''
+        Calculate a metric dictionary for a boundary
+
+        If there is no data for a boundary, None is returned
+        '''
+        source_data = self.source_data_for_boundary(boundary)
+        if source_data:
+            return self.calculate(source_data)
+        else:
+            return None
+
+    def calculate_by_location(self, location):
+        '''
+        Calculate a metric dictionary for a (lon, lat) location
+
+        If there is no data for a location, None is returned
+        '''
+        for source_data in self.source_data_for_location(location):
+            calculation = self.calculate(source_data)
+            if calculation:
+                return calculation
+        return None
 
 
-class FakeAlgorithm(BaseAlgorithm):
-    def calculate(self, point):
-        lon, lat = point
-        coord_fmt = '{:0.4f}'
-        lon_st = coord_fmt.format(lon)
-        lat_st = coord_fmt.format(lat)
-        slug = slugify(self.metric.name)
-        path = "fake/{}/{},{}/".format(slug, lon_st, lat_st)
-        random.seed(path)
-        score = random.randint(0, 100) / 100.0
-        value = random.randint(0, 100) / 100.0
-        citation = OrderedDict((
-            ('path', '/api/citation/' + path),
-            ('label', 'Fake Data Citation'),
-            ('year', 2010),
-            ('type', 'fake'),
-            ('id', '{},{}'.format(lon_st, lat_st)),
-        ))
-        boundary = OrderedDict((
-            ('path', '/api/boundary/' + path),
-            ('label', 'Fake Data Boundary'),
-            ('year', 2010),
-            ('type', 'fake'),
-            ('id', '{},{}'.format(lon_st, lat_st)),
-        ))
-        score = OrderedDict((
-            ("score", score),
-            ("value", value),
-            ("value_type", "percent"),
-            ("description", self.metric.description),
-            ("citation_path", citation['path']),
-            ("boundary_path", boundary['path']),
-        ))
-        return score, citation, boundary
+class PlaceholderAlgorithm(BaseAlgorithm):
+    '''Placeholder for data that we plan to import in the future'''
+
+    class PlaceholderData(object):
+        '''Randomized data that is consistant for a boundary/node combo'''
+        def __init__(self, boundary, seed):
+            self.boundary = boundary
+            random.seed(seed)
+            self.score = random.randint(0, 100) / 100.0
+            self.value = random.randint(0, 100) / 100.0
+
+    def boundary_path(self, boundary):
+        return reverse(
+            'api:fake-boundary', kwargs={'slug': boundary.slug})
+
+    def boundaries_for_location(self, location):
+        '''Return a fake Boundary, roughly 1/2 sq. mile'''
+        return [fake_boundary(location, 2)]
+
+    def source_data_for_boundary(self, boundary):
+        seed = self.detail_path(boundary)
+        return self.PlaceholderData(boundary, seed)
+
+    def score(self, source_data):
+        score_text = (
+            "We don't have data for {node.label} yet, but studies show it"
+            " has an impact on the health of a community. Do you know about"
+            " a data source? <a href='{feedback_url}'>Tell us about it</a>."
+        ).format(node=self.node, feedback_url='#')
+        return {
+            'summary': OrderedDict((
+                ("score", source_data.score),
+                ("value", source_data.value),
+                ("value_type", "percent"),
+                ("description", self.metric.description),
+            )),
+            'detail': OrderedDict((
+                ("score_text", score_text),
+            )),
+            'boundary': OrderedDict((
+                ("label", "Future Data Placeholder"),
+                ("type", "Placeholder"),
+            )),
+        }
 
 
-class FoodStampAlgorithm(BaseAlgorithm):
-    def calculate(self, point):
-        for boundary in boundaries(point):
+class CensusPercentAlgorithm(BaseAlgorithm):
+    '''
+    Algorithm for census-based calcuations of ratio vs. the state average
+    '''
+    # Default boundary set order
+    boundary_set_slugs = (
+        'census-block-groups',
+        'census-tracts',
+        'counties',
+        'states',)
+
+    def source_data_for_boundary(self, boundary):
+        '''Get census data where the total population is not 0'''
+        total_fields, _ = self.get_fields()
+        empty_totals = {field: 0 for field in total_fields}
+        try:
+            source_data = Census.objects.exclude(
+                **empty_totals).get(boundary=boundary)
+        except Census.DoesNotExist:
+            return None
+        else:
+            return source_data
+
+    def boundaries_for_location(self, location):
+        '''Generate census boundaries containing the point, smallest first'''
+        wkt = 'POINT({} {})'.format(*location)
+        for set_slug in self.boundary_set_slugs:
             try:
-                data = Census.objects.filter(boundary=boundary).exclude(
-                    B19058_001E=0).first()
-            except Census.DoesNotExist:
+                boundary = Boundary.objects.get(
+                    set__slug=set_slug, shape__contains=wkt)
+            except Boundary.DoesNotExist:
                 pass
             else:
-                break
-        boundary = boundary_dict(data.boundary)
-        citation = OrderedDict((
-            ('path', '/api/citation/census/B19058/'),
-            ('label', 'Census 5 Year Summary, 2008-2012'),
-            ('year', 2012),
-            ('type', 'percent'),
-            ('id', 'B19058'),
-        ))
-        total = data.B19058_001E
-        on_stamps = data.B19058_002E
-        percent = on_stamps / float(total)
-        state_avg = 0.138
-        state_std_dev = 0.106
-        score = 1.0 - norm.cdf(percent, state_avg, state_std_dev)
+                yield boundary
 
-        score = OrderedDict((
-            ("score", round(score, 3)),
-            ("value", round(percent, 3)),
-            ("average", state_avg),
-            ("std_dev", state_std_dev),
-            ("value_type", "percent"),
-            ("description", self.metric.description),
-            ("citation_path", citation['path']),
-            ("boundary_path", boundary['path']),
-        ))
-        return score, citation, boundary
+    def score(self, source_data):
+        '''
+        Score based on the ratio vs the state ratio
+
+        For example, the metric 'Percentage on Food Stamps' comes from Census
+        table B19058.  The total households is item 1, and the count on food
+        stamps or other assistance is item 2.  The percent for any one census
+        tract is the count divided by the total.  The score is the percent of
+        census tracts across the state that have a lower percentage on food
+        stamps, which can be calculated using the cumulative distribution
+        function (CDF) with the tract's ratio, the state average, and the
+        state standard deviation.  The last two can be pre-calcuated.
+        '''
+        total_fields, target_fields = self.get_fields()
+        total = sum([getattr(source_data, f) for f in total_fields])
+        target = sum([getattr(source_data, f) for f in target_fields])
+        percent = float(target) / float(total)
+        avg, std_dev, better_sign = self.get_stats(source_data)
+        cdf = norm.cdf(percent, avg, std_dev)
+        if better_sign >= 0:
+            score = cdf
+        else:
+            score = 1.0 - cdf
+        return {
+            'summary': OrderedDict((
+                ("score", round(score, 3)),
+                ("value", round(percent, 3)),
+                ("average", avg),
+                ("std_dev", std_dev),
+                ("value_type", "percent"),
+                ("description", self.metric.description),
+            )),
+            'detail': OrderedDict((
+            )),
+            'boundary': OrderedDict((
+                ("label", source_data.boundary.display_name),
+                ("type", source_data.boundary.kind),
+                ("external_id", source_data.boundary.external_id)
+            )),
+        }
+
+    def get_fields(self):
+        '''
+        Return data field names on source data
+
+        Returns a two-element tuple:
+        - total_fields - Names of fields with population totals
+        - target_fields - Names of fields with target group counts
+        '''
+        pattern = self.table + '_{:03}E'
+        total_fields = [pattern.format(f) for f in self.total_column_ids]
+        target_fields = [pattern.format(f) for f in self.target_column_ids]
+        return total_fields, target_fields
+
+    def get_stats(self, source_data):
+        '''
+        Return population statistics
+
+        Return is a 3-element tuple:
+        - average - The average value for the population
+        - standard deviation - The standard deviation for the population
+        - better_sign - Positive if higher than average is good, negative if
+          lower than average is good.
+        '''
+        raise NotImplementedError('get_stats not implemented')
 
 
-class PercentPovertyAlgorithm(BaseAlgorithm):
-    def calculate(self, point):
-        for boundary in boundaries(point):
-            try:
-                data = Census.objects.filter(boundary=boundary).exclude(
-                    B17001_001E=0).first()
-            except Census.DoesNotExist:
-                pass
-            else:
-                break
-        boundary = boundary_dict(data.boundary)
-        citation = OrderedDict((
-            ('path', '/api/citation/census/B17001/'),
-            ('label', 'Census 5 Year Summary, 2008-2012'),
-            ('year', 2012),
-            ('type', 'percent'),
-            ('id', 'B17001'),
-        ))
-        total = data.B17001_001E
-        in_poverty = data.B17001_002E
-        percent = in_poverty / float(total)
-        state_avg = 0.166
-        state_std_dev = 0.118383
-        score = 1.0 - norm.cdf(percent, state_avg, state_std_dev)
+class FoodStampAlgorithm(CensusPercentAlgorithm):
+    '''Score based on percentage of households on food stamps/assistance'''
 
-        score = OrderedDict((
-            ("score", round(score, 3)),
-            ("value", round(percent, 3)),
-            ("average", state_avg),
-            ("std_dev", state_std_dev),
-            ("value_type", "percent"),
-            ("description", self.metric.description),
-            ("citation_path", citation['path']),
-            ("boundary_path", boundary['path']),
-        ))
-        return score, citation, boundary
+    table = 'B19058'
+    total_column_ids = (1,)
+    target_column_ids = (2,)
+
+    def get_stats(self, source_data):
+        '''Stats for census tracts in Oklahoma'''
+        average = 0.138
+        std_dev = 0.106
+        better_sign = -1
+        return average, std_dev, better_sign
+
+
+class PercentPovertyAlgorithm(CensusPercentAlgorithm):
+    '''Score based on percentage of households under povery level'''
+
+    table = 'B17001'
+    total_column_ids = (1,)
+    target_column_ids = (2,)
+
+    def get_stats(self, source_data):
+        '''Stats for census tracts in Oklahoma'''
+        average = 0.166
+        std_dev = 0.118383
+        better_sign = -1
+        return average, std_dev, better_sign

--- a/healthdata/migrations/0003_del_unused_fields_from_scoremetric.py
+++ b/healthdata/migrations/0003_del_unused_fields_from_scoremetric.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'ScoreMetric.data_property'
+        db.delete_column(u'healthdata_scoremetric', 'data_property')
+
+        # Deleting field 'ScoreMetric.data_source'
+        db.delete_column(u'healthdata_scoremetric', 'data_source_id')
+
+        # Deleting field 'ScoreMetric.boundary_set'
+        db.delete_column(u'healthdata_scoremetric', 'boundary_set_id')
+
+
+    def backwards(self, orm):
+        # Adding field 'ScoreMetric.data_property'
+        db.add_column(u'healthdata_scoremetric', 'data_property',
+                      self.gf('django.db.models.fields.CharField')(max_length=50, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'ScoreMetric.data_source'
+        db.add_column(u'healthdata_scoremetric', 'data_source',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['contenttypes.ContentType'], null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'ScoreMetric.boundary_set'
+        db.add_column(u'healthdata_scoremetric', 'boundary_set',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['boundaryservice.BoundarySet'], null=True, blank=True),
+                      keep_default=False)
+
+
+    models = {
+        u'boundaryservice.boundary': {
+            'Meta': {'ordering': "('kind', 'display_name')", 'object_name': 'Boundary'},
+            'centroid': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '4269', 'null': 'True'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'kind': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'metadata': ('boundaryservice.fields.JSONField', [], {'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '192', 'db_index': 'True'}),
+            'set': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'boundaries'", 'to': u"orm['boundaryservice.BoundarySet']"}),
+            'shape': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '4269'}),
+            'simple_shape': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '4269'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '256'})
+        },
+        u'boundaryservice.boundaryset': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'BoundarySet'},
+            'authority': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'count': ('django.db.models.fields.IntegerField', [], {}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'href': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'kind_first': ('django.db.models.fields.BooleanField', [], {}),
+            'last_updated': ('django.db.models.fields.DateField', [], {}),
+            'metadata_fields': ('boundaryservice.fields.ListField', [], {'separator': "'|'", 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'singular': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '256'})
+        },
+        u'healthdata.protohealth': {
+            'Meta': {'object_name': 'ProtoHealth'},
+            'boundary': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['boundaryservice.Boundary']", 'null': 'True', 'blank': 'True'}),
+            'deaths': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'fips': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mammography_rate': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'ozone_days': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'perc_children_poverty': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'perc_fast_food': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'perc_lbw': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'perc_limited_food': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'perc_obese': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'perc_poor': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'perc_smokers': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'perc_unemployed': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'population': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'std_rate': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'teen_birth_rate': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'violent_crime': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'healthdata.scoremetric': {
+            'Meta': {'object_name': 'ScoreMetric'},
+            'algorithm': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'description': ('django.db.models.fields.CharField', [], {'default': "'This is a description'", 'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'params': ('jsonfield.fields.JSONField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        },
+        u'healthdata.scorenode': {
+            'Meta': {'object_name': 'ScoreNode'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'metric': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['healthdata.ScoreMetric']", 'null': 'True', 'blank': 'True'}),
+            'parent': ('mptt.fields.TreeForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['healthdata.ScoreNode']"}),
+            'rel_order': ('django.db.models.fields.IntegerField', [], {'default': '100'}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'weight': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        }
+    }
+
+    complete_apps = ['healthdata']

--- a/healthdata/models.py
+++ b/healthdata/models.py
@@ -61,15 +61,6 @@ class ScoreMetric(models.Model):
     description = models.CharField(
         max_length=255, default="This is a description",
         help_text='Human-readable description')
-    data_source = models.ForeignKey(
-        ContentType, null=True, blank=True,
-        help_text='Model that Holds the Source Data')
-    boundary_set = models.ForeignKey(
-        BoundarySet, null=True, blank=True,
-        help_text='Related Boundary Set with Data')
-    data_property = models.CharField(
-        max_length=50, null=True, blank=True,
-        help_text='Data property used for source data')
     algorithm = models.IntegerField(
         choices=[(a[0], a[2]) for a in algorithm_choices],
         default=PLACEHOLDER_ALGORITHM,

--- a/healthdata/models.py
+++ b/healthdata/models.py
@@ -44,11 +44,12 @@ class ProtoHealth(models.Model):
 class ScoreMetric(models.Model):
     '''A metric that has a score for a given location'''
 
-    FAKE_ALGORITHM = 0
+    PLACEHOLDER_ALGORITHM = 0
     FOOD_STAMP_ALGORITHM = 1
     PERCENT_POVERTY_ALGORITHM = 2
     algorithm_choices = (
-        (FAKE_ALGORITHM, 'FakeAlgorithm', 'Fake Algorithm'),
+        (PLACEHOLDER_ALGORITHM, 'PlaceholderAlgorithm',
+            'Placeholder Algorithm'),
         (FOOD_STAMP_ALGORITHM, 'FoodStampAlgorithm', 'Food Stamp Algorithm'),
         (PERCENT_POVERTY_ALGORITHM, 'PercentPovertyAlgorithm',
          'Percent Poverty Algorithm'),
@@ -71,7 +72,7 @@ class ScoreMetric(models.Model):
         help_text='Data property used for source data')
     algorithm = models.IntegerField(
         choices=[(a[0], a[2]) for a in algorithm_choices],
-        default=FAKE_ALGORITHM,
+        default=PLACEHOLDER_ALGORITHM,
         help_text='Algorithm used to calculate score')
     params = JSONField(
         default='', null=True, blank=True,
@@ -80,13 +81,16 @@ class ScoreMetric(models.Model):
     def __str__(self):
         return self.name
 
-    def get_algorithm(self):
+    def get_algorithm(self, node):
         klass = getattr(algorithms, self.algorithm_class_name[self.algorithm])
-        algorithm = klass(self)
+        algorithm = klass(node, self)
         return algorithm
 
-    def score(self, point):
-        return self.get_algorithm().calculate(point)
+    def score_by_boundary(self, node, boundary):
+        return self.get_algorithm(node).calculate_by_boundary(boundary)
+
+    def score_by_location(self, node, location):
+        return self.get_algorithm(node).calculate_by_location(location)
 
 
 class ScoreNode(MPTTModel):
@@ -109,3 +113,15 @@ class ScoreNode(MPTTModel):
 
     def __str__(self):
         return self.label
+
+    def score_by_boundary(self, boundary):
+        if self.metric:
+            return self.metric.score_by_boundary(self, boundary)
+        else:
+            return None
+
+    def score_by_location(self, location):
+        if self.metric:
+            return self.metric.score_by_location(self, location)
+        else:
+            return None

--- a/healthdata/tests/test_serializers.py
+++ b/healthdata/tests/test_serializers.py
@@ -1,14 +1,106 @@
 import json
 
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase as BaseAPITestCase
 
-from healthdata.models import ScoreNode, ScoreMetric
-from healthdata.serializers import ScoreNodeSerializer
+from healthdata.models import Boundary, ScoreNode, ScoreMetric
+from healthdata.serializers import (
+    MetricDetailSerializer, ScoreNodeSerializer)
+
+
+class APITestCase(BaseAPITestCase):
+    maxDiff = None
+
+    def assertSerializerDataEqual(self, expected, actual):
+        '''
+        assert serializer.data is equal to a dictionary
+
+        Because serializer.data includes dict-like objects that aren't quite
+        dicts, it passed through json encoding/decoding first, to get a
+        plain old dict (with unicode strings)
+        '''
+        data = json.loads(json.dumps(actual))
+        self.assertEqual(expected, data)
+
+
+class MetricDetailSerializerTest(APITestCase):
+    def setUp(self):
+        self.parent_node = ScoreNode.objects.create(
+            slug='parent', label='Parent', weight=1, parent=None)
+        self.metric_a = ScoreMetric.objects.create(
+            name=u'Metric A', description=u'The first metric',
+            algorithm=ScoreMetric.PLACEHOLDER_ALGORITHM, params={})
+        self.node_a = ScoreNode.objects.create(
+            slug='metric-a', label='Metric A', metric=self.metric_a, weight=2,
+            parent=self.parent_node)
+
+    def test_detail_fake_boundary(self):
+        shape = (
+            "MULTIPOLYGON(((-95.99 36.15, -95.99 36.16, -95.98 36.16,"
+            " -95.98 36.15, -95.99 36.15)))")
+        centroid = "POINT(-95.985 36.155)"
+        fake_boundary = Boundary(
+            shape=shape, centroid=centroid, name='fake',
+            display_name='Pending Data', kind='Pending Data',
+            slug='fake_2_-95.99_36.15')
+        serializer = MetricDetailSerializer(
+            fake_boundary, context={'node': self.node_a})
+        expected = {
+            u'id': u'fake_2_-95.99_36.15',
+            u'type': u'Feature',
+            u'geometry': {
+                u'type': u'MultiPolygon',
+                u'coordinates': [[[
+                    [-95.99, 36.15],
+                    [-95.99, 36.16],
+                    [-95.98, 36.16],
+                    [-95.98, 36.15],
+                    [-95.99, 36.15],
+                ]]]},
+            u'properties': {
+                u'name': u'fake',
+                u'display_name': u'Pending Data',
+                u'external_id': u'',
+                u'kind': u'Pending Data',
+                u'centroid': {
+                    u'type': u'Point',
+                    u'coordinates': [-95.985, 36.155],
+                },
+                u'element': {
+                    u'label': u'Metric A',
+                    u'slug': u'metric-a',
+                    u'weight': 2,
+                    u'metric': {
+                        u'summary': {
+                            u'score': 0.46,
+                            u'value': 0.36,
+                            u'value_type': u'percent',
+                            u'description': u'The first metric',
+                        },
+                        u'detail': {
+                            u'path': (
+                                u'/api/detail/fake_2_-95.99_36.15/metric-a/'),
+                            u'score_text': (
+                                u"We don't have data for Metric A yet, but"
+                                u" studies show it has an impact on the"
+                                u" health of a community. Do you know about a"
+                                u" data source?"
+                                u" <a href='#'>Tell us about it</a>."
+                            ),
+                        },
+                        u'boundary': {
+                            u'path': u'/api/boundary/fake_2_-95.99_36.15/',
+                            u'label': u'Future Data Placeholder',
+                            u'type': u'Placeholder',
+                        },
+                    },
+                    u'children': [],
+                },
+            }
+        }
+        self.assertSerializerDataEqual(expected, serializer.data)
 
 
 class ScoreSerializerTest(APITestCase):
-    maxDiff = None
-
     def setUp(self):
         self.grandma_node = ScoreNode.objects.create(
             slug='grandma', label='Grandma', weight=1)
@@ -16,13 +108,13 @@ class ScoreSerializerTest(APITestCase):
             slug='parent', label='Parent', weight=1, parent=self.grandma_node)
         self.metric_a = ScoreMetric.objects.create(
             name=u'Metric A', description=u'The first metric',
-            algorithm=ScoreMetric.FAKE_ALGORITHM, params={})
+            algorithm=ScoreMetric.PLACEHOLDER_ALGORITHM, params={})
         self.node_a = ScoreNode.objects.create(
             slug='metric-a', label='Metric A', metric=self.metric_a, weight=2,
             parent=self.parent_node)
         self.metric_b = ScoreMetric.objects.create(
             name=u'Metric B', description=u'The second metric',
-            algorithm=ScoreMetric.FAKE_ALGORITHM, params={})
+            algorithm=ScoreMetric.PLACEHOLDER_ALGORITHM, params={})
         self.node_b = ScoreNode.objects.create(
             slug='metric-b', label='Metric B', metric=self.metric_b, weight=1,
             parent=self.parent_node)
@@ -39,25 +131,15 @@ class ScoreSerializerTest(APITestCase):
         data = json.loads(json.dumps(actual))
         self.assertEqual(expected, data)
 
-    def boundary_a_rep(self):
+    def boundary_rep(self):
         '''Boundary for first metric'''
         return {
-            u'path': u'/api/boundary/fake/metric-a/-95.9910,36.1499/',
-            u'id': u'-95.9910,36.1499',
-            u'label': u'Fake Data Boundary',
-            u'type': u'fake',
-            u'year': 2010,
+            u'path': u'/api/boundary/fake_2_-96.00_36.14/',
+            u'label': u'Future Data Placeholder',
+            u'type': u'Placeholder',
         }
 
-    def boundary_b_rep(self):
-        '''Boundary for second metric'''
-        return {
-            u'path': u'/api/boundary/fake/metric-b/-95.9910,36.1499/',
-            u'id': u'-95.9910,36.1499',
-            u'label': u'Fake Data Boundary',
-            u'type': u'fake',
-            u'year': 2010,
-        }
+    boundary_a_rep = boundary_b_rep = boundary_rep
 
     def citation_a_rep(self):
         '''Citation for first metric'''
@@ -86,18 +168,21 @@ class ScoreSerializerTest(APITestCase):
             u"slug": u"metric-a",
             u"weight": 2,
             u"metric": {
-                u'score': {
-                    u"score": 0.73,
-                    u"value": 0.61,
+                u'summary': {
+                    u"score": 0.35,
+                    u"value": 0.2,
                     u"value_type": u"percent",
                     u"description": u"The first metric",
-                    u"citation_path": (
-                        u"/api/citation/fake/metric-a/-95.9910,36.1499/"),
-                    u"boundary_path": (
-                        u"/api/boundary/fake/metric-a/-95.9910,36.1499/"),
                 },
-                u'citation': self.citation_a_rep(),
-                u'boundary': self.boundary_a_rep(),
+                u'detail': {
+                    u"path": u"/api/detail/fake_2_-96.00_36.14/metric-a/",
+                    u"score_text": (
+                        u"We don't have data for Metric A yet, but studies"
+                        u" show it has an impact on the health of a community."
+                        u" Do you know about a data source? <a href='#'>Tell"
+                        u" us about it</a>."),
+                },
+                u'boundary': self.boundary_rep(),
             },
             u"children": [],
         }
@@ -108,18 +193,21 @@ class ScoreSerializerTest(APITestCase):
             u"slug": u"metric-b",
             u"weight": 1,
             u"metric": {
-                u'score': {
-                    u"score": 0.78,
-                    u"value": 0.2,
+                u'summary': {
+                    u"score": 0.8,
+                    u"value": 0.87,
                     u"value_type": u"percent",
                     u"description": u"The second metric",
-                    u"citation_path": (
-                        u"/api/citation/fake/metric-b/-95.9910,36.1499/"),
-                    u"boundary_path": (
-                        u"/api/boundary/fake/metric-b/-95.9910,36.1499/"),
                 },
-                u'citation': self.citation_b_rep(),
-                u'boundary': self.boundary_b_rep(),
+                u'detail': {
+                    u"path": u"/api/detail/fake_2_-96.00_36.14/metric-b/",
+                    u"score_text": (
+                        u"We don't have data for Metric B yet, but studies"
+                        u" show it has an impact on the health of a community."
+                        u" Do you know about a data source? <a href='#'>Tell"
+                        u" us about it</a>."),
+                },
+                u'boundary': self.boundary_rep(),
             },
             u"children": [],
         }

--- a/healthdata/tests/test_utils.py
+++ b/healthdata/tests/test_utils.py
@@ -1,9 +1,8 @@
 '''Tests for healthdata/utils.py'''
 
-from boundaryservice.models import Boundary, BoundarySet
 from django.test import TestCase
 
-from healthdata.utils import fake_boundary, boundaries_for_location
+from healthdata.utils import fake_boundary
 
 
 class FakeBoundaryUtilTest(TestCase):
@@ -12,9 +11,9 @@ class FakeBoundaryUtilTest(TestCase):
 
     def test_fake_2(self):
         boundary = fake_boundary(self.location, 2)
-        self.assertEqual('fake', boundary.name)
-        self.assertEqual('Pending Data', boundary.display_name)
-        self.assertEqual('Pending Data', boundary.kind)
+        self.assertEqual('Placeholder', boundary.name)
+        self.assertEqual('Future Data Placeholder', boundary.display_name)
+        self.assertEqual('Future Data Placeholder', boundary.kind)
         self.assertFalse(boundary.external_id)
         self.assertFalse(boundary.id)
         self.assertEqual('fake_2_-96.00_36.14', boundary.slug)
@@ -26,9 +25,9 @@ class FakeBoundaryUtilTest(TestCase):
 
     def test_fake_3(self):
         boundary = fake_boundary(self.location, 3)
-        self.assertEqual('fake', boundary.name)
-        self.assertEqual('Pending Data', boundary.display_name)
-        self.assertEqual('Pending Data', boundary.kind)
+        self.assertEqual('Placeholder', boundary.name)
+        self.assertEqual('Future Data Placeholder', boundary.display_name)
+        self.assertEqual('Future Data Placeholder', boundary.kind)
         self.assertFalse(boundary.external_id)
         self.assertFalse(boundary.id)
         self.assertEqual('fake_3_-95.991_36.149', boundary.slug)
@@ -37,60 +36,3 @@ class FakeBoundaryUtilTest(TestCase):
             (-95.99, 36.149), (-95.991, 36.149)),),)
         self.assertEqual(expected_shape, boundary.shape.coords)
         self.assertEqual((-95.9905, 36.1495), boundary.centroid.coords)
-
-
-class BoundariesForLocation(TestCase):
-    def setUp(self):
-        self.location = (-95.9910, 36.1499)
-        self.tract_set = BoundarySet.objects.create(
-            name='Census Tract',
-            slug='census-tracts',
-            kind_first=True,
-            last_updated='2014-05-21',
-            count=0,
-            metadata_fields=['GEOID'])
-
-    def test_fake(self):
-        boundaries = list(boundaries_for_location(self.location, ['fake_3']))
-        self.assertEqual(1, len(boundaries))
-        boundary = boundaries[0]
-        self.assertEqual('fake_3_-95.991_36.149', boundary.slug)
-
-    def test_real(self):
-        shape = (
-            'MULTIPOLYGON ((('
-            '-96.00269 36.14836, -96.00269 36.15019, -96.00154 36.15488, '
-            '-96.00169 36.15608, -96.00138 36.15608, -96.00149 36.15648, '
-            '-96.00091 36.15798, -96.00060 36.15807, -95.99898 36.16035, '
-            '-95.99903 36.16052, -95.99776 36.16078, -95.99788 36.16099, '
-            '-95.99532 36.16147, -95.99286 36.16221, -95.99030 36.16237, '
-            '-95.98693 36.16103, -95.98393 36.16057, -95.98096 36.15979, '
-            '-95.98068 36.15918, -95.98038 36.15274, -95.98059 36.14949, '
-            '-95.97970 36.14593, -95.98005 36.14427, -95.98061 36.14340, '
-            '-95.98136 36.14282, -95.98243 36.14243, -95.98381 36.14245, '
-            '-95.98732 36.14377, -95.99231 36.14423, -95.99455 36.14526, '
-            '-95.99611 36.14555, -95.99969 36.14541, -96.00045 36.14555, '
-            '-96.00182 36.14595, -96.00224 36.14639, -96.00260 36.14702, '
-            '-96.00269 36.14836)))')
-        tract = Boundary.objects.create(
-            slug='census-tract-25',
-            set=self.tract_set,
-            metadata={'GEOID': '40143002500'},
-            external_id='40143002500',
-            shape=shape,
-            display_name='Census Tract 25',
-            simple_shape=shape)
-        boundaries = list(
-            boundaries_for_location(self.location, ['census-tracts']))
-        self.assertEqual(1, len(boundaries))
-        boundary = boundaries[0]
-        self.assertEqual(boundary, tract)
-
-    def test_bad_set_slug_raises(self):
-        gen = boundaries_for_location(self.location, ['bad-slug'])
-        self.assertRaises(BoundarySet.DoesNotExist, list, gen)
-
-    def test_no_boundaries_found(self):
-        boundaries = list(
-            boundaries_for_location(self.location, ['census-tracts']))
-        self.assertFalse(boundaries)

--- a/healthdata/tests/test_utils.py
+++ b/healthdata/tests/test_utils.py
@@ -1,0 +1,96 @@
+'''Tests for healthdata/utils.py'''
+
+from boundaryservice.models import Boundary, BoundarySet
+from django.test import TestCase
+
+from healthdata.utils import fake_boundary, boundaries_for_location
+
+
+class FakeBoundaryUtilTest(TestCase):
+    def setUp(self):
+        self.location = (-95.9910, 36.1499)
+
+    def test_fake_2(self):
+        boundary = fake_boundary(self.location, 2)
+        self.assertEqual('fake', boundary.name)
+        self.assertEqual('Pending Data', boundary.display_name)
+        self.assertEqual('Pending Data', boundary.kind)
+        self.assertFalse(boundary.external_id)
+        self.assertFalse(boundary.id)
+        self.assertEqual('fake_2_-96.00_36.14', boundary.slug)
+        expected_shape = (((
+            (-96., 36.14), (-96., 36.15), (-95.99, 36.15), (-95.99, 36.14),
+            (-96., 36.14)),),)
+        self.assertEqual(expected_shape, boundary.shape.coords)
+        self.assertEqual((-95.995, 36.145), boundary.centroid.coords)
+
+    def test_fake_3(self):
+        boundary = fake_boundary(self.location, 3)
+        self.assertEqual('fake', boundary.name)
+        self.assertEqual('Pending Data', boundary.display_name)
+        self.assertEqual('Pending Data', boundary.kind)
+        self.assertFalse(boundary.external_id)
+        self.assertFalse(boundary.id)
+        self.assertEqual('fake_3_-95.991_36.149', boundary.slug)
+        expected_shape = (((
+            (-95.991, 36.149), (-95.991, 36.15), (-95.99, 36.15),
+            (-95.99, 36.149), (-95.991, 36.149)),),)
+        self.assertEqual(expected_shape, boundary.shape.coords)
+        self.assertEqual((-95.9905, 36.1495), boundary.centroid.coords)
+
+
+class BoundariesForLocation(TestCase):
+    def setUp(self):
+        self.location = (-95.9910, 36.1499)
+        self.tract_set = BoundarySet.objects.create(
+            name='Census Tract',
+            slug='census-tracts',
+            kind_first=True,
+            last_updated='2014-05-21',
+            count=0,
+            metadata_fields=['GEOID'])
+
+    def test_fake(self):
+        boundaries = list(boundaries_for_location(self.location, ['fake_3']))
+        self.assertEqual(1, len(boundaries))
+        boundary = boundaries[0]
+        self.assertEqual('fake_3_-95.991_36.149', boundary.slug)
+
+    def test_real(self):
+        shape = (
+            'MULTIPOLYGON ((('
+            '-96.00269 36.14836, -96.00269 36.15019, -96.00154 36.15488, '
+            '-96.00169 36.15608, -96.00138 36.15608, -96.00149 36.15648, '
+            '-96.00091 36.15798, -96.00060 36.15807, -95.99898 36.16035, '
+            '-95.99903 36.16052, -95.99776 36.16078, -95.99788 36.16099, '
+            '-95.99532 36.16147, -95.99286 36.16221, -95.99030 36.16237, '
+            '-95.98693 36.16103, -95.98393 36.16057, -95.98096 36.15979, '
+            '-95.98068 36.15918, -95.98038 36.15274, -95.98059 36.14949, '
+            '-95.97970 36.14593, -95.98005 36.14427, -95.98061 36.14340, '
+            '-95.98136 36.14282, -95.98243 36.14243, -95.98381 36.14245, '
+            '-95.98732 36.14377, -95.99231 36.14423, -95.99455 36.14526, '
+            '-95.99611 36.14555, -95.99969 36.14541, -96.00045 36.14555, '
+            '-96.00182 36.14595, -96.00224 36.14639, -96.00260 36.14702, '
+            '-96.00269 36.14836)))')
+        tract = Boundary.objects.create(
+            slug='census-tract-25',
+            set=self.tract_set,
+            metadata={'GEOID': '40143002500'},
+            external_id='40143002500',
+            shape=shape,
+            display_name='Census Tract 25',
+            simple_shape=shape)
+        boundaries = list(
+            boundaries_for_location(self.location, ['census-tracts']))
+        self.assertEqual(1, len(boundaries))
+        boundary = boundaries[0]
+        self.assertEqual(boundary, tract)
+
+    def test_bad_set_slug_raises(self):
+        gen = boundaries_for_location(self.location, ['bad-slug'])
+        self.assertRaises(BoundarySet.DoesNotExist, list, gen)
+
+    def test_no_boundaries_found(self):
+        boundaries = list(
+            boundaries_for_location(self.location, ['census-tracts']))
+        self.assertFalse(boundaries)

--- a/healthdata/tests/test_views.py
+++ b/healthdata/tests/test_views.py
@@ -1,31 +1,14 @@
 import json
 
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase as BaseAPITestCase
 
 from healthdata.models import ScoreNode, ScoreMetric
 
 
-class ScoreAPIViewTest(APITestCase):
+class APITestCase(BaseAPITestCase):
     maxDiff = None
 
-    def setUp(self):
-        self.parent_node = ScoreNode.objects.create(
-            slug='parent', label='Parent', weight=1)
-        self.metric_a = ScoreMetric.objects.create(
-            name=u'Metric A', description=u'The first metric',
-            algorithm=ScoreMetric.FAKE_ALGORITHM, params={})
-        self.node_a = ScoreNode.objects.create(
-            slug='metric-a', label='Metric A', metric=self.metric_a, weight=2,
-            parent=self.parent_node)
-        self.metric_b = ScoreMetric.objects.create(
-            name=u'Metric B', description=u'The second metric',
-            algorithm=ScoreMetric.FAKE_ALGORITHM, params={})
-        self.node_b = ScoreNode.objects.create(
-            slug='metric-b', label='Metric B', metric=self.metric_b, weight=1,
-            parent=self.parent_node)
-        self.url = '/api/score/-95.991,36.1499/'
-
-    def assertResponseDataEqual(self, expected, actual):
+    def assertDataEqual(self, response, expected):
         '''
         assert Response data is equal to a dictionary
 
@@ -33,8 +16,110 @@ class ScoreAPIViewTest(APITestCase):
         passed through json encoding/decoding first, to get a plain old dict
         (with unicode strings)
         '''
+        self.assertEqual(response.status_code, 200, response.content)
+        actual = response.data
         data = json.loads(json.dumps(actual))
         self.assertEqual(expected, data)
+
+
+class DetailAPIViewTest(APITestCase):
+
+    def setUp(self):
+        self.metric_a = ScoreMetric.objects.create(
+            name=u'Metric A', description=u'The first metric',
+            algorithm=ScoreMetric.PLACEHOLDER_ALGORITHM, params={})
+        self.node_a = ScoreNode.objects.create(
+            slug='metric-a', label='Metric A', metric=self.metric_a, weight=2)
+        self.url = (
+            '/api/detail/fake_4_-95.9910_36.1499/metric-a/')
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        expected = {
+            u'id': u'fake_4_-95.9910_36.1499',
+            u'type': u'Feature',
+            u'geometry': {
+                u'type': u'MultiPolygon',
+                u'coordinates': [[[
+                    [-95.991, 36.1499],
+                    [-95.991, 36.15],
+                    [-95.9909, 36.15],
+                    [-95.9909, 36.1499],
+                    [-95.991, 36.1499],
+                ]]]},
+            u'properties': {
+                u'name': u'Placeholder',
+                u'display_name': u'Future Data Placeholder',
+                u'external_id': u'',
+                u'kind': u'Future Data Placeholder',
+                u'centroid': {
+                    u'type': u'Point',
+                    u'coordinates': [-95.99095, 36.14995],
+                },
+                u'metric': {
+                    u'label': u'Metric A',
+                    u'slug': u'metric-a',
+                    u'description': u'The first metric',
+                    u'weight': 2,
+                    u'score': 0.53,
+                    u'score_text': (
+                        u"We don't have data for Metric A yet, but studies"
+                        u" show it has an impact on the health of a"
+                        u" community. Do you know about a data source?"
+                        u" <a href='#'>Tell us about it</a>."
+                    ),
+                    u'value': 0.46,
+                    u'value_type': u'percent',
+                },
+            }
+        }
+        self.assertDataEqual(response, expected)
+
+
+class FakeBoundaryAPIView(APITestCase):
+    def test_get(self):
+        url = '/api/boundary/fake_2_-95.99_36.15/'
+        response = self.client.get(url)
+        expected = {
+            u'geometry': {
+                u'coordinates': [[[
+                    [-95.99, 36.15],
+                    [-95.99, 36.16],
+                    [-95.98, 36.16],
+                    [-95.98, 36.15],
+                    [-95.99, 36.15]]]],
+                u'type': u'MultiPolygon'},
+            u'type': u'Feature',
+            u'id': u'fake_2_-95.99_36.15',
+            u'properties': {
+                u'centroid': {
+                    u'coordinates': [-95.985, 36.155],
+                    u'type': u'Point'},
+                u'display_name': u'Future Data Placeholder',
+                u'external_id': u'',
+                u'kind': u'Future Data Placeholder',
+                u'name': u'Placeholder'}}
+        self.assertDataEqual(response, expected)
+
+
+class ScoreAPIViewTest(APITestCase):
+
+    def setUp(self):
+        self.parent_node = ScoreNode.objects.create(
+            slug='parent', label='Parent', weight=1)
+        self.metric_a = ScoreMetric.objects.create(
+            name=u'Metric A', description=u'The first metric',
+            algorithm=ScoreMetric.PLACEHOLDER_ALGORITHM, params={})
+        self.node_a = ScoreNode.objects.create(
+            slug='metric-a', label='Metric A', metric=self.metric_a, weight=2,
+            parent=self.parent_node)
+        self.metric_b = ScoreMetric.objects.create(
+            name=u'Metric B', description=u'The second metric',
+            algorithm=ScoreMetric.PLACEHOLDER_ALGORITHM, params={})
+        self.node_b = ScoreNode.objects.create(
+            slug='metric-b', label='Metric B', metric=self.metric_b, weight=1,
+            parent=self.parent_node)
+        self.url = '/api/score/-95.991,36.1499/'
 
     def test_get(self):
         response = self.client.get(self.url)
@@ -43,64 +128,42 @@ class ScoreAPIViewTest(APITestCase):
                 u'label': u'Parent',
                 u'slug': u'parent',
                 u'weight': 1,
-                u'score': 0.75,
+                u'score': 0.5,
                 u'elements': [{
                     u'label': u'Metric A',
                     u'slug': u'metric-a',
                     u'description': u'The first metric',
                     u'weight': 2,
-                    u'score': 0.73,
-                    u'value': 0.61,
+                    u'score': 0.35,
+                    u'value': 0.2,
                     u'value_type': u'percent',
-                    u'citation_path': (
-                        u'/api/citation/fake/metric-a/-95.9910,36.1499/'),
-                    u'boundary_path': (
-                        u'/api/boundary/fake/metric-a/-95.9910,36.1499/'),
+                    u'boundary_id': u'fake_2_-96.00_36.14',
+                    u'detail_uri': (
+                        u'http://testserver'
+                        u'/api/detail/fake_2_-96.00_36.14/metric-a/'),
                 }, {
                     u'label': u'Metric B',
                     u'slug': u'metric-b',
                     u'description': u'The second metric',
                     u'weight': 1,
-                    u'score': 0.78,
-                    u'value': 0.2,
+                    u'score': 0.8,
+                    u'value': 0.87,
                     u'value_type': u'percent',
-                    u'citation_path': (
-                        u'/api/citation/fake/metric-b/-95.9910,36.1499/'),
-                    u'boundary_path': (
-                        u'/api/boundary/fake/metric-b/-95.9910,36.1499/'),
+                    u'boundary_id': u'fake_2_-96.00_36.14',
+                    u'detail_uri': (
+                        u'http://testserver'
+                        u'/api/detail/fake_2_-96.00_36.14/metric-b/'),
                 }],
             }],
-            u'citations': {
-                u'/api/citation/fake/metric-a/-95.9910,36.1499/': {
-                    u'path': u'/api/citation/fake/metric-a/-95.9910,36.1499/',
-                    u'id': u'-95.9910,36.1499',
-                    u'year': 2010,
-                    u'type': u'fake',
-                    u'label': u'Fake Data Citation',
-                },
-                u'/api/citation/fake/metric-b/-95.9910,36.1499/': {
-                    u'path': u'/api/citation/fake/metric-b/-95.9910,36.1499/',
-                    u'id': u'-95.9910,36.1499',
-                    u'year': 2010,
-                    u'type': u'fake',
-                    u'label': u'Fake Data Citation',
-                },
-            },
             u'boundaries': {
-                u'/api/boundary/fake/metric-a/-95.9910,36.1499/': {
-                    u'path': u'/api/boundary/fake/metric-a/-95.9910,36.1499/',
-                    u'id': u'-95.9910,36.1499',
-                    u'year': 2010,
-                    u'type': u'fake',
-                    u'label': u'Fake Data Boundary',
-                },
-                u'/api/boundary/fake/metric-b/-95.9910,36.1499/': {
-                    u'path': u'/api/boundary/fake/metric-b/-95.9910,36.1499/',
-                    u'id': u'-95.9910,36.1499',
-                    u'year': 2010,
-                    u'type': u'fake',
-                    u'label': u'Fake Data Boundary',
+                u'fake_2_-96.00_36.14': {
+                    u'path': u'/api/boundary/fake_2_-96.00_36.14/',
+                    u'uri': (
+                        u'http://testserver'
+                        u'/api/boundary/fake_2_-96.00_36.14/'),
+                    u'type': u'Placeholder',
+                    u'label': u'Future Data Placeholder',
                 },
             },
         }
-        self.assertResponseDataEqual(expected, response.data)
+        self.assertDataEqual(response, expected)

--- a/healthdata/urls.py
+++ b/healthdata/urls.py
@@ -1,7 +1,8 @@
 from django.conf.urls import include, patterns, url
 from django.views.generic import TemplateView
 
-from .views import BoundaryAPIView, ScoreAPIView
+from .views import (
+    BoundaryAPIView, DetailAPIView, FakeBoundaryAPIView, ScoreAPIView)
 
 api_urls = patterns(
     '',
@@ -10,8 +11,13 @@ api_urls = patterns(
         'healthdata.views.score_by_location'),
     url(r'^score/(?P<lon>-?[\d.]+),(?P<lat>-?[\d.]+)/$',
         ScoreAPIView.as_view(), name='score'),
+    url(r'^boundary/(?P<slug>fake_[-_\d.]*)/$',
+        FakeBoundaryAPIView.as_view(), name='fake-boundary'),
     url(r'^boundary/(?P<slug>[a-z\-_\d]*)/$', BoundaryAPIView.as_view(),
         name='boundary'),
+    url(r'^detail/(?P<boundary_slug>[a-z\-_\d.]*)'
+        r'/(?P<node_slug>[a-z\-_\d]*)/$',
+        DetailAPIView.as_view(), name='metric-detail'),
 )
 
 urlpatterns = patterns(

--- a/healthdata/utils.py
+++ b/healthdata/utils.py
@@ -1,19 +1,35 @@
 from boundaryservice.models import Boundary, BoundarySet
 from data.models import Census
 
-def stand_dev_form(total, target):
-	tract_set = BoundarySet.objects.all()[1]
-	ok_data = Boundary.objects.get(slug='oklahoma-state')
-	ok_data_new = Census.objects.filter(boundary=ok_data).values_list(total, target)
-	data = Census.objects.filter(boundary__set=tract_set).values_list(total, target)
-	ok_percentile = float(ok_data_new[0][1]/ok_data_new[0][0])
-	count = 0
-	total = 0.0
-	for tracts in data:
-		if tracts[0] != 0:
-			total += (float(tracts[1]/tracts[0]) - ok_percentile)**2
-			count += 1
-	total = (total/count)**(0.5)
-	return total
 
+def std_dev_across_tracts(total_col, target_cols):
+    '''
+    Calcuate the standard deviation across Oklahoma census tracts
 
+    total_col = Column with the population total
+    target_cols = Columns with the count meeting the criteria.
+    '''
+    # Get average for all Oklahoma
+    # TODO: Why did the slug change between database loads?
+    ok_state = Boundary.objects.get(set__slug='states', external_id=40)
+    ok_data = Census.objects.filter(
+        boundary=ok_state).values_list(total_col, *target_cols)[0]
+    ok_total = ok_data[0]
+    ok_values = ok_data[1:]
+    ok_percentile = sum(ok_values) / float(ok_total)
+
+    # Calculate standard deviation of tracts
+    tract_set = BoundarySet.objects.get(slug='census-tracts')
+    tract_rows = Census.objects.filter(
+        boundary__set=tract_set).values_list(total_col, *target_cols)
+    count = 0
+    total = 0.0
+    for row in tract_rows:
+        tract_total = row[0]
+        tract_values = row[1:]
+        if tract_total != 0:
+            tract_percentage = sum(tract_values) / float(tract_total)
+            total += (tract_percentage - ok_percentile)**2
+            count += 1
+    std_dev = (total/count)**(0.5)
+    return std_dev

--- a/healthdata/utils.py
+++ b/healthdata/utils.py
@@ -13,6 +13,7 @@ def std_dev_across_tracts(total_col, target_cols):
     '''
     # Get average for all Oklahoma
     # TODO: Why did the slug change between database loads?
+    # 'oklahoma-state' on one box, 'state-oklahoma' on another
     ok_state = Boundary.objects.get(set__slug='states', external_id=40)
     ok_data = Census.objects.filter(
         boundary=ok_state).values_list(total_col, *target_cols)[0]
@@ -79,31 +80,7 @@ def fake_boundary(location, precision):
         '{bot_lon:0.{precision}f}_'
         '{bot_lat:0.{precision}f}').format(**params)
     boundary = Boundary(
-        shape=shape_wkt, display_name='Pending Data', kind='Pending Data',
-        slug=fake_slug, centroid=centroid_wkt, name='fake')
+        shape=shape_wkt, display_name='Future Data Placeholder',
+        kind='Future Data Placeholder',
+        slug=fake_slug, centroid=centroid_wkt, name='Placeholder')
     return boundary
-
-
-def boundaries_for_location(location, set_slugs):
-    '''
-    Generate Boundaries for a location
-
-    location - a (lon, lat) pair of floats
-    set_slugs - a list of BoundarySet slugs, like 'census-tracts' or
-        'states'.  The boundaries are returned in this order.  A slug
-        of 'fake_2' will generate a fake Boundary with two decimals of
-        precision (about a mile tall).
-    '''
-    wkt = 'POINT({} {})'.format(*location)
-    for boundary_slug in set_slugs:
-        if boundary_slug.startswith('fake_'):
-            _, precision = boundary_slug.split('_', 2)
-            boundary = fake_boundary(location, int(precision))
-        else:
-            boundary_set = BoundarySet.objects.get(slug=boundary_slug)
-            try:
-                boundary = Boundary.objects.get(
-                    set=boundary_set, shape__contains=wkt)
-            except Boundary.DoesNotExist:
-                continue
-        yield boundary

--- a/healthdata/utils.py
+++ b/healthdata/utils.py
@@ -1,3 +1,5 @@
+from math import floor
+
 from boundaryservice.models import Boundary, BoundarySet
 from data.models import Census
 
@@ -33,3 +35,75 @@ def std_dev_across_tracts(total_col, target_cols):
             count += 1
     std_dev = (total/count)**(0.5)
     return std_dev
+
+
+def fake_boundary(location, precision):
+    '''
+    Returns a rectangular fake Boundary
+
+    precision determines the size of the Boundary.  2 is about 1 mile tall,
+    and width varies by latitude
+    '''
+
+    def round_down(val):
+        factor = pow(10, precision)
+        return floor(val * factor) / factor
+
+    lon, lat = location
+    factor = pow(10, precision)
+    increment = 1.0 / factor
+    params = {
+        'bot_lon': floor(lon * factor) / factor,
+        'bot_lat': floor(lat * factor) / factor,
+        'precision': precision,
+        'pplus': precision + 1,
+    }
+    params['top_lon'] = params['bot_lon'] + increment
+    params['top_lat'] = params['bot_lat'] + increment
+    params['ctr_lon'] = params['bot_lon'] + (increment / 2)
+    params['ctr_lat'] = params['bot_lat'] + (increment / 2)
+    shape_wkt = (
+        "MULTIPOLYGON((("
+        "{bot_lon:0.{precision}f} {bot_lat:0.{precision}f},"
+        "{bot_lon:0.{precision}f} {top_lat:0.{precision}f},"
+        "{top_lon:0.{precision}f} {top_lat:0.{precision}f},"
+        "{top_lon:0.{precision}f} {bot_lat:0.{precision}f},"
+        "{bot_lon:0.{precision}f} {bot_lat:0.{precision}f}"
+        ")))").format(**params)
+    centroid_wkt = (
+        "POINT("
+        "{ctr_lon:0.{pplus}f} {ctr_lat:0.{pplus}f}"
+        ")").format(**params)
+    fake_slug = (
+        'fake_{precision}_'
+        '{bot_lon:0.{precision}f}_'
+        '{bot_lat:0.{precision}f}').format(**params)
+    boundary = Boundary(
+        shape=shape_wkt, display_name='Pending Data', kind='Pending Data',
+        slug=fake_slug, centroid=centroid_wkt, name='fake')
+    return boundary
+
+
+def boundaries_for_location(location, set_slugs):
+    '''
+    Generate Boundaries for a location
+
+    location - a (lon, lat) pair of floats
+    set_slugs - a list of BoundarySet slugs, like 'census-tracts' or
+        'states'.  The boundaries are returned in this order.  A slug
+        of 'fake_2' will generate a fake Boundary with two decimals of
+        precision (about a mile tall).
+    '''
+    wkt = 'POINT({} {})'.format(*location)
+    for boundary_slug in set_slugs:
+        if boundary_slug.startswith('fake_'):
+            _, precision = boundary_slug.split('_', 2)
+            boundary = fake_boundary(location, int(precision))
+        else:
+            boundary_set = BoundarySet.objects.get(slug=boundary_slug)
+            try:
+                boundary = Boundary.objects.get(
+                    set=boundary_set, shape__contains=wkt)
+            except Boundary.DoesNotExist:
+                continue
+        yield boundary

--- a/healthdata/views.py
+++ b/healthdata/views.py
@@ -10,7 +10,9 @@ from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.response import Response
 
 from .models import ScoreNode
-from .serializers import BoundarySerializer, ScoreNodeSerializer
+from .serializers import (
+    BoundarySerializer, MetricDetailSerializer, ScoreNodeSerializer)
+from .utils import fake_boundary
 
 
 def fake_api(request):
@@ -128,6 +130,77 @@ class BoundaryAPIView(RetrieveAPIView):
     serializer_class = BoundarySerializer
 
 
+def fake_boundary_from_slug(fake_slug):
+    '''Create a fake Boundary from a path slug'''
+    _, raw_res, raw_lon, raw_lat = fake_slug.split('_', 4)
+    location = (float(raw_lon), float(raw_lat))
+    precision = int(raw_res)
+    return fake_boundary(location, precision)
+
+
+class DetailAPIView(RetrieveAPIView):
+    model = Boundary
+    serializer_class = MetricDetailSerializer
+
+    def transform_data(self, raw_data):
+        '''Transform the raw MetricDetailSerializer data'''
+        data = raw_data.copy()
+        elem = data['properties'].pop('element')
+
+        # Element should be a leaf node
+        children = elem.pop('children')
+        assert not children
+
+        # Extract summary and detail items
+        metric = elem.pop('metric')
+        for key, val in metric['summary'].items():
+            elem[key] = val
+        for key, val in metric['detail'].items():
+            if key != 'path':
+                elem[key] = val
+
+        data['properties']['metric'] = elem
+        return data
+
+    def get_object(self, queryset=None):
+        '''Get the boundary, generating a fake boundary as needed'''
+        boundary_slug = self.kwargs['boundary_slug']
+        if boundary_slug.startswith('fake_'):
+            boundary = fake_boundary_from_slug(boundary_slug)
+        else:
+            boundary = Boundary.objects.get(slug=boundary_slug)
+        return boundary
+
+    def get_serializer_context(self):
+        '''Add the node to the context'''
+        context = super(DetailAPIView, self).get_serializer_context()
+        node_slug = self.kwargs['node_slug']
+        node = ScoreNode.objects.filter(slug=node_slug).latest('id')
+        context['node'] = node
+        return context
+
+    def retrieve(self, request, *args, **kwargs):
+        '''
+        Convert raw node serialization to wire serialization
+
+        Copy of rest_framework/mixins/RetrieveModelMixin.retrieve,
+        but transforms the raw MetricDetailSerializer data.
+        '''
+        self.object = self.get_object()
+        serializer = self.get_serializer(self.object)
+        raw_data = serializer.data
+        data = self.transform_data(raw_data)
+        return Response(data)
+
+
+class FakeBoundaryAPIView(RetrieveAPIView):
+    model = Boundary
+    serializer_class = BoundarySerializer
+
+    def get_object(self, queryset=None):
+        return fake_boundary_from_slug(self.kwargs['slug'])
+
+
 class ScoreAPIView(ListAPIView):
     serializer_class = ScoreNodeSerializer
     queryset = ScoreNode.objects.filter(parent=None)
@@ -144,14 +217,12 @@ class ScoreAPIView(ListAPIView):
         data = OrderedDict((
             ('elements', []),
             ('boundaries', {}),
-            ('citations', {}),
         ))
         for raw in raw_data:
             transformed = self.transform_raw_element(raw)
             element, boundaries, citations = transformed
             data['elements'].append(element)
             data['boundaries'].update(boundaries)
-            data['citations'].update(citations)
         return data
 
     def transform_raw_element(self, raw):
@@ -166,12 +237,25 @@ class ScoreAPIView(ListAPIView):
         if raw['metric']:
             assert not raw['children']
             metric = raw['metric']
-            for key, value in metric['score'].items():
+            for key, value in metric['summary'].items():
                 element[key] = value
+
+            # Extract boundary
             boundary = metric['boundary']
-            boundaries[boundary['path']] = boundary
-            citation = metric['citation']
-            citations[citation['path']] = citation
+            boundary_path = boundary['path']
+            boundary['uri'] = (
+                self.request.build_absolute_uri(boundary_path))
+            boundary_path_prefix = '/api/boundary/'
+            assert boundary_path.startswith(boundary_path_prefix)
+            assert boundary_path.endswith('/')
+            boundary_id = boundary_path[len(boundary_path_prefix):-1]
+            boundaries[boundary_id] = boundary
+            element['boundary_id'] = boundary_id
+
+            # Extract detail URI
+            detail_path = metric['detail']['path']
+            element['detail_uri'] = (
+                self.request.build_absolute_uri(detail_path))
         if raw['children']:
             assert not raw['metric']
             total_score = 0.0


### PR DESCRIPTION
John, Patrick - This will change the return from /api/score.  JSON might be similar enough, but I haven't tried running your code yet, so the breakage is unknown.  I plan to merge and ship tonight, so tell me if you need the live site to stay stable today.

In short, the URLs are becoming real, and we'll start integrating live census data this week.

/api/score is a bit different.  Citations are dropped entirely, replaced with a 'detail_uri'.  The detail URI points to /api/detail/<boundary_id>/<node_id>/, that serves a GeoJSON representation of the boundary plus metric.  Boundary IDs are shorter.  Fake boundary slugs have changed, and now the fake boundaries are returned at /api/boundaries as well.

The biggest changes are backend.  Algorithms are almost entirely different.  Joe hasn't issued a pull request, so I expect a painful merge this week.  I'll start moving more logic into the database, so you might be doing a lot of `git pull; ./manage.py loaddata scores` in the future.
